### PR TITLE
Add notice to project creation endpoint [SCI-5295]

### DIFF
--- a/source/includes/_projects.md
+++ b/source/includes/_projects.md
@@ -121,6 +121,10 @@ curl -X POST \
 
 This endpoint creates a new project in the team.
 
+<aside class="notice">
+  Created project has no automatically assigned users, therefore in order to access this project it is needed to create [user_projects](#project_users) record for it.
+</aside>
+
 ### HTTP Request
 
 `POST https://<server-name>/api/v1/teams/<TEAM_ID>/projects`


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->